### PR TITLE
Update the environment to make working on dros easier

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1,0 +1,2 @@
+file kernel.elf
+target remote localhost:1234

--- a/ansible/roles/dev/files/bashrc
+++ b/ansible/roles/dev/files/bashrc
@@ -1,0 +1,32 @@
+# .bashrc
+
+# Source global definitions
+if [ -f /etc/bashrc ]; then
+    . /etc/bashrc
+fi
+
+export PATH=/usr/local/bin/i686-dros-toolchain/bin/:$PATH
+
+# User specific aliases and functions
+dbuild() {
+    pushd ~/devel/dros
+    cmake -DCMAKE_TOOLCHAIN_FILE=~/devel/dros/arch/i386/toolchain-gcc-i386.cmake .
+    make
+    popd
+}
+
+drun() {
+    if [ ! -f ~/devel/dros/kernel.elf ]; then
+        dbuild
+    fi
+
+    qemu-system-i386 -display curses -kernel ~/devel/dros/kernel.elf
+}
+
+ddebug() {
+    if [ ! -f ~/devel/dros/kernel.elf ]; then
+        dbuild
+    fi
+
+    qemu-system-i386 -s -S -display curses -kernel ~/devel/dros/kernel.elf
+}

--- a/ansible/roles/dev/files/gdbinit
+++ b/ansible/roles/dev/files/gdbinit
@@ -1,0 +1,1 @@
+add-auto-load-safe-path /home/vagrant/devel/dros/.gdbinit

--- a/ansible/roles/dev/tasks/main.yml
+++ b/ansible/roles/dev/tasks/main.yml
@@ -20,6 +20,8 @@
     - qemu-system-x86
     - texinfo
     - xorriso
+    - vim
+    - ncurses
 
 - name: Create cross-compiler build directory
   file: path=/home/vagrant/cross-compiler state=directory mode=0755
@@ -69,3 +71,8 @@
     - make install-gcc
     - make install-target-libgcc
 
+- name: Enable GDB auto-loading
+  copy: src=gdbinit dest=/home/{{ ansible_env.SUDO_USER }}/.gdbinit
+
+- name: Add custom bashrc
+  copy: src=bashrc dest=/home/{{ ansible_env.SUDO_USER }}/.bashrc


### PR DESCRIPTION
This adds a gdbinit file that will automatically load kernel and attach
to the remote port QEMU starts on when launched with the `-s` option.
It also adds several helpful functions to the .bashrc of the Vagrant
user.

This fixes issue #9 
